### PR TITLE
Apply changes on a bookmark to existing popup dynamically

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -226,16 +226,16 @@ async function onBookmarkChanged(id, changeInfo) {
     id
   });
   if (responded) {
-  const changes = {};
-  if ('title' in changeInfo)
-    changes.name = changeInfo.title;
-  if ('url' in changeInfo)
-    changes.url = changeInfo.url;
-  browser.runtime.sendMessage({
-    action: 'bookmark-changed',
-    id,
-    ...changes,
-  });
+    const changes = {};
+    if ('title' in changeInfo)
+      changes.name = changeInfo.title;
+    if ('url' in changeInfo)
+      changes.url = changeInfo.url;
+    browser.runtime.sendMessage({
+      action: 'bookmark-changed',
+      id,
+      ...changes,
+    });
   }
 }
 
@@ -249,20 +249,20 @@ async function onBookmarkMoved(id, moveInfo) {
     id
   });
   if (responded) {
-  const tree = await browser.bookmarks.getTree();
-  const folders = [];
-  for (const node of tree[0].children) {
-    const folder = getFolder(node);
-    if (folder) {
-      folders.push(folder);
+    const tree = await browser.bookmarks.getTree();
+    const folders = [];
+    for (const node of tree[0].children) {
+      const folder = getFolder(node);
+      if (folder) {
+        folders.push(folder);
+      }
     }
-  }
-  browser.runtime.sendMessage({
-    action: 'bookmark-moved',
-    id,
-    parentId: moveInfo.parentId,
-    folders,
-  });
+    browser.runtime.sendMessage({
+      action: 'bookmark-moved',
+      id,
+      parentId: moveInfo.parentId,
+      folders,
+    });
   }
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -181,8 +181,8 @@ async function onBookmarkCreated(id, bookmark, isEdit) {
     newBookmark.isFolder = bookmark.type === 'folder';
     newBookmark.isEdit = isEdit;
 
-    if (bookmark.isFolder) {
-      const children = (await browser.bookmarks.getChildren(bookmark.id))
+    if (newBookmark.isFolder) {
+      const children = (await browser.bookmarks.getChildren(newBookmark.id))
         .filter(child => child.type === 'bookmark');
       for (const child of children) {
         newBookmark.children.push({
@@ -201,7 +201,7 @@ async function onBookmarkCreated(id, bookmark, isEdit) {
       }
     }
 
-    const matches = bookmark.url.match(new RegExp(`#${info.preferences['redirect-key'].value}-(.*)`));
+    const matches = newBookmark.url.match(new RegExp(`#${info.preferences['redirect-key'].value}-(.*)`));
     newBookmark.containerId = matches ? matches[1] : 'none';
 
     newBookmark.windowId = (await browser.windows.create({

--- a/src/background.js
+++ b/src/background.js
@@ -204,7 +204,14 @@ async function onBookmarkCreated(id, bookmark, isEdit) {
   }
 }
 
-function onBookmarkChanged(id, changeInfo) {
+async function onBookmarkChanged(id, changeInfo) {
+  const responded = await browser.runtime.sendMessage({
+    action: 'check-popup-existence-for-bookmark',
+    id
+  });
+  if (!responded)
+    return;
+
   const changes = {};
   if ('title' in changeInfo)
     changes.name = changeInfo.title;
@@ -218,6 +225,13 @@ function onBookmarkChanged(id, changeInfo) {
 }
 
 async function onBookmarkMoved(id, moveInfo) {
+  const responded = await browser.runtime.sendMessage({
+    action: 'check-popup-existence-for-bookmark',
+    id
+  });
+  if (!responded)
+    return;
+
   const tree = await browser.bookmarks.getTree();
   const folders = [];
   for (const node of tree[0].children) {

--- a/src/background.js
+++ b/src/background.js
@@ -67,32 +67,33 @@ async function onMessageReceived(message) {
     case 'get-info': {
       await getPreferences();
 
-      info.folders = [];
-      info.containers = [];
+      const currentFolders = [];
+      const currentContainers = [];
 
       const tree = await browser.bookmarks.getTree();
       for (const node of tree[0].children) {
         const folder = getFolder(node);
         if (folder) {
-          info.folders.push(folder);
+          currentFolders.push(folder);
         }
       }
 
       const containers = await browser.contextualIdentities.query({});
       for (const container of containers) {
-        info.containers.push({
+        currentContainers.push({
           id: getContainerId(container.name),
           name: container.name,
         });
       }
 
-      const bookmark = bookmarks[message.id];
-      delete bookmarks[message.id];
-
       response = {
         ...info,
-        bookmark
+        folders: currentFolders,
+        containers: currentContainers,
+        bookmark: bookmarks[message.id],
       };
+
+      delete bookmarks[message.id];
 
       break;
     }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -19,8 +19,10 @@ getInfo();
 
 async function getInfo() {
   try {
+    const id = location.hash.replace(/^#/, '');
     info = await browser.runtime.sendMessage({
       action: 'get-info',
+      id
     });
 
     let title = '';

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -167,6 +167,11 @@ function clearOptions(dropdown) {
 
 function onMessageReceived(message) {
   switch (message.action) {
+    case 'check-popup-existence-for-bookmark': {
+      if (message.id == info.bookmark.id)
+        return Promise.resolve(true);
+      break;
+    }
     case 'bookmark-changed': {
       if (message.id != info.bookmark.id)
         break;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -186,6 +186,7 @@ function onMessageReceived(message) {
     case 'bookmark-moved': {
       if (message.id != info.bookmark.id)
         break;
+      clearOptions(folderDropdown);
       addOptions(folderDropdown, info.folders = message.folders);
       folderDropdown.value = info.bookmark.parentId = message.parentId;
       break;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -13,6 +13,7 @@ const doneButton = document.getElementById('done-button');
 containerDropdown.addEventListener('change', onContainerDropdownChanged);
 cancelButton.addEventListener('click', onCancelButtonClicked);
 doneButton.addEventListener('click', onDoneButtonClicked);
+browser.runtime.onMessage.addListener(onMessageReceived);
 
 getInfo();
 
@@ -153,6 +154,34 @@ function addOptions(dropdown, options, level = 0) {
 
     if (option.children && option.children.length > 0) {
       addOptions(dropdown, option.children, level + 2);
+    }
+  }
+}
+
+function clearOptions(dropdown) {
+  const range = document.createRange();
+  range.selectNodeContents(dropdown);
+  range.deleteContents;
+  range.detach();
+}
+
+function onMessageReceived(message) {
+  switch (message.action) {
+    case 'bookmark-changed': {
+      if (message.id != info.bookmark.id)
+        break;
+      if ('name' in message)
+        nameField.value = info.bookmark.name = message.name;
+      if ('url' in message)
+        urlField.value = info.bookmark.url = message.url;
+      break;
+    }
+    case 'bookmark-moved': {
+      if (message.id != info.bookmark.id)
+        break;
+      addOptions(folderDropdown, info.folders = message.folders);
+      folderDropdown.value = info.bookmark.parentId = message.parentId;
+      break;
     }
   }
 }


### PR DESCRIPTION
Hello,

My addon [Tree Style Tab](https://addons.mozilla.org/firefox/addon/tree-style-tab/) provides ability to create bookmarks from a tree of tabs. This means that multiple bookmarks are created at a time and they are updated immediately to store tree structure information.

On the other hand, Container Bookmarks's current implementation is not designed for cases: mutliple bookmarks are created at a time, or a created bookmark is updated immediately by another addon. As the result, the popup of Container Bookmarks can be broken and it unexpectedly overwrites changes done by other addons while the popup is open.

This PR mainly does two changes:

1. Handle multiple bookmarks created at a time more safely.
2. Introduces listeners for changes of created bookmarks, and they update existing popups dynamically.

I think the first change should improve compatibility with Firefox's native "Bookmark All/Selected Tabs" feature, and both changes should improve compatibility with other bookmark related addon not only TST.

How about this change?